### PR TITLE
MANTA-4847 add instances and generic config data to rust-triton-clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea/*

--- a/sapi/Cargo.toml
+++ b/sapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sapi"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["bowrocker <jon.anderson@joyent.com>", "rui@joyent.com"]
 edition = "2018"
 

--- a/sapi/Cargo.toml
+++ b/sapi/Cargo.toml
@@ -19,6 +19,7 @@ serde_urlencoded = "0.5"
 slog = { version = "2.4.1", features = [ "max_level_trace" ] }
 slog-stdlog = "3"
 uuid = "0.7"
+unicode-normalization = "=0.1.5"
 
 [dev-dependencies]
 slog-term = "2.4.0"

--- a/sapi/Cargo.toml
+++ b/sapi/Cargo.toml
@@ -8,17 +8,11 @@ edition = "2018"
 version = "0.9.20"
 features = ["hyper-011"]
 [dependencies]
-miniz_oxide = "= 0.2.3"
-miniz_oxide_c_api = "= 0.2.2"
-flate2 = "= 1.0.9"
-joyent-rust-utils = { git = "https://github.com/joyent/rust-utils" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-serde_urlencoded = "0.5"
 slog = { version = "2.4.1", features = [ "max_level_trace" ] }
 slog-stdlog = "3"
-uuid = "0.7"
 unicode-normalization = "=0.1.5"
 
 [dev-dependencies]

--- a/sapi/Cargo.toml
+++ b/sapi/Cargo.toml
@@ -11,6 +11,7 @@ features = ["hyper-011"]
 miniz_oxide = "= 0.2.3"
 miniz_oxide_c_api = "= 0.2.2"
 flate2 = "= 1.0.9"
+joyent-rust-utils = { git = "https://github.com/joyent/rust-utils" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/sapi/Cargo.toml
+++ b/sapi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sapi"
 version = "0.2.0"
-authors = ["bowrocker <jon.anderson@joyent.com>"]
+authors = ["bowrocker <jon.anderson@joyent.com>", "rui@joyent.com"]
 edition = "2018"
 
 [dependencies.reqwest]

--- a/sapi/examples/basic.rs
+++ b/sapi/examples/basic.rs
@@ -1,3 +1,5 @@
+// Copyright 2020 Joyent, Inc.
+
 use slog::{error, info, o, Drain, Logger};
 use std::sync::Mutex;
 
@@ -9,6 +11,16 @@ fn main() {
     );
 
     let client = sapi::SAPI::new("http://sapi.ruidc0.joyent.us", 60, log.clone());
+
+    let sdc_app = client.get_application_by_name("sdc").expect("sdc_app");
+
+    assert_eq!(sdc_app.len(), 1);
+
+    let sdc_app_data = sdc_app[0].clone();
+    let sdc_app_metadata = sdc_app_data.metadata.expect("app metadata");
+    let app_admin_login = sdc_app_metadata["ufds_admin_login"].clone();
+
+    assert_eq!(app_admin_login.as_str(), Some("admin"));
 
     let mut sapi_svc = client
         .get_service_by_name("sapi")

--- a/sapi/examples/basic.rs
+++ b/sapi/examples/basic.rs
@@ -23,7 +23,7 @@ fn main() {
 
     match client.get_zone_config(&zone_uuid) {
         Ok(resp) => {
-            info!(log, "config: {:?}", resp);
+            info!(log, "config: {:#?}", resp);
         }
         Err(e) => error!(log, "error: {:?}", e),
     }

--- a/sapi/examples/basic.rs
+++ b/sapi/examples/basic.rs
@@ -11,9 +11,13 @@ fn main() {
     let client = sapi::SAPI::new("http://sapi.ruidc0.joyent.us", 60, log.clone());
 
     let services = client.list_services().unwrap();
-    dbg!(services);
+    dbg!(&services);
 
-    let zone_uuid = String::from("f8bf03e3-5636-4cc4-a939-bbca6b4547f0");
+    let svc = &services[0];
+    let svc_uuid = &svc.uuid;
+
+    let instances = client.list_service_instances(svc_uuid).unwrap();
+    let zone_uuid = &instances[0].uuid;
 
     match client.get_zone_config(&zone_uuid) {
         Ok(resp) => {

--- a/sapi/examples/basic.rs
+++ b/sapi/examples/basic.rs
@@ -14,7 +14,8 @@ fn main() {
         .get_service_by_name("sapi")
         .expect("get sapi service");
 
-    assert_eq!(sapi_svc.metadata["SERVICE_NAME"], "sapi");
+
+    assert_eq!(sapi_svc.metadata.unwrap()["SERVICE_NAME"], "sapi");
 
     let services = client.list_services().expect("list services");
     dbg!(&services);

--- a/sapi/examples/basic.rs
+++ b/sapi/examples/basic.rs
@@ -10,13 +10,15 @@ fn main() {
 
     let client = sapi::SAPI::new("http://sapi.ruidc0.joyent.us", 60, log.clone());
 
-    let services = client.list_services().unwrap();
+    let services = client.list_services().expect("list services");
     dbg!(&services);
 
     let svc = &services[0];
     let svc_uuid = &svc.uuid;
 
-    let instances = client.list_service_instances(svc_uuid).unwrap();
+    let instances = client
+        .list_service_instances(svc_uuid)
+        .expect("list service instances");
     let zone_uuid = &instances[0].uuid;
 
     match client.get_zone_config(&zone_uuid) {

--- a/sapi/examples/basic.rs
+++ b/sapi/examples/basic.rs
@@ -1,6 +1,5 @@
 use slog::{error, info, o, Drain, Logger};
 use std::sync::Mutex;
-use joyent_rust_utils::net;
 
 fn main() {
     let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
@@ -9,9 +8,11 @@ fn main() {
         o!("build-id" => "0.1.0"),
     );
 
-    let sapi_ip = net::lookup_ip("sapi.ruidc0.joyent.us").unwrap();
-    let sapi_url = format!("http://{}", sapi_ip);
-    let client = sapi::SAPI::new(&sapi_url, 60, log.clone());
+    let client = sapi::SAPI::new("http://sapi.ruidc0.joyent.us", 60, log.clone());
+
+    let services = client.list_services().unwrap();
+    dbg!(services);
+
     let zone_uuid = String::from("f8bf03e3-5636-4cc4-a939-bbca6b4547f0");
 
     match client.get_zone_config(&zone_uuid) {

--- a/sapi/examples/basic.rs
+++ b/sapi/examples/basic.rs
@@ -1,5 +1,6 @@
 use slog::{error, info, o, Drain, Logger};
 use std::sync::Mutex;
+use joyent-rust-utils::net;
 
 fn main() {
     let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
@@ -8,7 +9,9 @@ fn main() {
         o!("build-id" => "0.1.0"),
     );
 
-    let client = sapi::SAPI::new("http://10.77.77.136", 60, log.clone());
+    let sapi_ip = net::lookup_ip("sapi.ruidc0.joyent.us");
+    let sapi_url = format!("http://{}", sapi_ip);
+//    let client = sapi::SAPI::new("http://10.77.77.136", 60, log.clone());
     let zone_uuid = String::from("f8bf03e3-5636-4cc4-a939-bbca6b4547f0");
 
     match client.get_zone_config(&zone_uuid) {

--- a/sapi/examples/basic.rs
+++ b/sapi/examples/basic.rs
@@ -1,6 +1,6 @@
 use slog::{error, info, o, Drain, Logger};
 use std::sync::Mutex;
-use joyent-rust-utils::net;
+use joyent_rust_utils::net;
 
 fn main() {
     let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
@@ -9,9 +9,9 @@ fn main() {
         o!("build-id" => "0.1.0"),
     );
 
-    let sapi_ip = net::lookup_ip("sapi.ruidc0.joyent.us");
+    let sapi_ip = net::lookup_ip("sapi.ruidc0.joyent.us").unwrap();
     let sapi_url = format!("http://{}", sapi_ip);
-//    let client = sapi::SAPI::new("http://10.77.77.136", 60, log.clone());
+    let client = sapi::SAPI::new(&sapi_url, 60, log.clone());
     let zone_uuid = String::from("f8bf03e3-5636-4cc4-a939-bbca6b4547f0");
 
     match client.get_zone_config(&zone_uuid) {

--- a/sapi/examples/basic.rs
+++ b/sapi/examples/basic.rs
@@ -10,6 +10,12 @@ fn main() {
 
     let client = sapi::SAPI::new("http://sapi.ruidc0.joyent.us", 60, log.clone());
 
+    let sapi_svc = client
+        .get_service_by_name("sapi")
+        .expect("get sapi service");
+
+    assert_eq!(sapi_svc.metadata["SERVICE_NAME"], "sapi");
+
     let services = client.list_services().expect("list services");
     dbg!(&services);
 

--- a/sapi/examples/basic.rs
+++ b/sapi/examples/basic.rs
@@ -10,12 +10,17 @@ fn main() {
 
     let client = sapi::SAPI::new("http://sapi.ruidc0.joyent.us", 60, log.clone());
 
-    let sapi_svc = client
+    let mut sapi_svc = client
         .get_service_by_name("sapi")
         .expect("get sapi service");
 
+    assert_eq!(sapi_svc.len(), 1);
 
-    assert_eq!(sapi_svc.metadata.unwrap()["SERVICE_NAME"], "sapi");
+    let sapi_svc_data = sapi_svc.pop().expect("first sapi service");
+    let sapi_metadata = sapi_svc_data.metadata.expect("metadata");
+    let service_name = sapi_metadata["SERVICE_NAME"].clone();
+
+    assert_eq!(service_name.as_str(), Some("sapi"));
 
     let services = client.list_services().expect("list services");
     dbg!(&services);

--- a/sapi/src/lib.rs
+++ b/sapi/src/lib.rs
@@ -25,11 +25,6 @@ pub struct ZoneMetadata {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct Services {
-    metadata: Vec<ServiceData>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum ServiceType {
     Vm,
@@ -42,11 +37,12 @@ pub struct ServiceData {
     uuid: String,
     application_uuid: String,
     params: Value,
-    #[serde(default)]
-    metadata: Value,
+    metadata: Option<Value>,
     #[serde(default)]
     master: bool,
 }
+
+type Services = Vec<ServiceData>;
 
 /// The SAPI client
 #[derive(Debug)]
@@ -90,9 +86,9 @@ impl SAPI {
     /// List all services
     pub fn list_services(
         &self
-    ) -> Result<Vec<ServiceData>, Box<dyn std::error::Error>> {
+    ) -> Result<Services, Box<dyn std::error::Error>> {
         let url = format!("{}", self.sapi_base_url.clone() + "/services");
-        let sdata: Vec<ServiceData> = self.get(&url)?.json()?;
+        let sdata: Services = self.get(&url)?.json()?;
         Ok(sdata)
     }
 

--- a/sapi/src/lib.rs
+++ b/sapi/src/lib.rs
@@ -130,6 +130,15 @@ impl SAPI {
         Ok(sdata)
     }
 
+    pub fn get_service_by_name(
+        &self,
+        name: &str,
+    ) -> Result<ServiceData, Box<dyn std::error::Error>> {
+        let url = format!("{}/services?name={}", self.sapi_base_url.clone(), name);
+        let sdata: ServiceData = self.get(&url)?.json()?;
+        Ok(sdata)
+    }
+
     /// create the named service under the application with the passed UUID
     pub fn create_service(
         &self,

--- a/sapi/src/lib.rs
+++ b/sapi/src/lib.rs
@@ -29,9 +29,24 @@ struct Services {
     metadata: Vec<ServiceData>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceType {
+    Vm,
+    Agent,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ServiceData {
-   name: String,
+    name: String,
+    uuid: String,
+    application_uuid: String,
+    params: Value,
+    metadata: Value,
+    #[serde(rename = "type")]
+    svc_type: ServiceType,
+    #[serde(default)]
+    master: bool,
 }
 
 /// The SAPI client

--- a/sapi/src/lib.rs
+++ b/sapi/src/lib.rs
@@ -130,12 +130,9 @@ impl SAPI {
         Ok(sdata)
     }
 
-    pub fn get_service_by_name(
-        &self,
-        name: &str,
-    ) -> Result<ServiceData, Box<dyn std::error::Error>> {
+    pub fn get_service_by_name(&self, name: &str) -> Result<Services, Box<dyn std::error::Error>> {
         let url = format!("{}/services?name={}", self.sapi_base_url.clone(), name);
-        let sdata: ServiceData = self.get(&url)?.json()?;
+        let sdata: Services = self.get(&url)?.json()?;
         Ok(sdata)
     }
 

--- a/sapi/src/lib.rs
+++ b/sapi/src/lib.rs
@@ -8,8 +8,6 @@ use reqwest::hyper_011::header::{Accept, ContentType, Headers};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-
-
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct SapiManifests {
     pub uuid: String,
@@ -33,13 +31,6 @@ pub struct ZoneConfig {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum ServiceType {
-    Vm,
-    Agent,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ServiceData {
     pub name: String,
     pub uuid: String,
@@ -48,6 +39,9 @@ pub struct ServiceData {
     pub metadata: Option<Value>,
     #[serde(default)]
     pub master: bool,
+    // TODO: add the type field, which comes with sapi v2.0.
+    // In order to receive that field from sapi the "accept-version: 2" header
+    // field must be specified.
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -72,29 +66,21 @@ pub struct SAPI {
 
 impl SAPI {
     /// initialize SAPI client API
-    pub fn new(
-        sapi_base_url: &str,
-        request_timeout: u64,
-        log: Logger,
-    ) -> Self {
+    pub fn new(sapi_base_url: &str, request_timeout: u64, log: Logger) -> Self {
         let client = Client::builder()
             .timeout(Duration::from_secs(request_timeout))
             .build()
             .unwrap();
-        let sapi = SAPI {
-                sapi_base_url: sapi_base_url.into(),
-                request_timeout: request_timeout.into(),
-                client,
-                log: log.clone(),
-        };
-        sapi
+        SAPI {
+            sapi_base_url: sapi_base_url.into(),
+            request_timeout,
+            client,
+            log: log.clone(),
+        }
     }
 
     /// Retrieve the "zone" configuration by zone UUID.
-    pub fn get_zone_config(
-        &self,
-        uuid: &str
-    ) -> Result<ZoneConfig, Box<dyn std::error::Error>> {
+    pub fn get_zone_config(&self, uuid: &str) -> Result<ZoneConfig, Box<dyn std::error::Error>> {
         let url = format!("{}/configs/{}", self.sapi_base_url.clone(), uuid);
         let zconfig: ZoneConfig = self.get(&url)?.json()?;
         Ok(zconfig)
@@ -105,16 +91,13 @@ impl SAPI {
         &self,
         inst_uuid: &str,
     ) -> Result<InstanceData, Box<dyn std::error::Error>> {
-        let url = format!("{}/instances/{}", self.sapi_base_url.clone(),
-                          inst_uuid);
+        let url = format!("{}/instances/{}", self.sapi_base_url.clone(), inst_uuid);
         let instance: InstanceData = self.get(&url)?.json()?;
         Ok(instance)
     }
 
     /// List all instances
-    pub fn list_instances(
-        &self,
-    ) -> Result<Instances, Box<dyn std::error::Error>> {
+    pub fn list_instances(&self) -> Result<Instances, Box<dyn std::error::Error>> {
         let url = format!("{}/instances", self.sapi_base_url.clone());
         let instances: Instances = self.get(&url)?.json()?;
         Ok(instances)
@@ -124,28 +107,25 @@ impl SAPI {
         &self,
         svc_uuid: &str,
     ) -> Result<Instances, Box<dyn std::error::Error>> {
-        let url = format!("{}/instances?service_uuid={}", self.sapi_base_url
-            .clone(), svc_uuid);
+        let url = format!(
+            "{}/instances?service_uuid={}",
+            self.sapi_base_url.clone(),
+            svc_uuid
+        );
         let instances: Instances = self.get(&url)?.json()?;
         Ok(instances)
     }
 
     /// List all services
-    pub fn list_services(
-        &self
-    ) -> Result<Services, Box<dyn std::error::Error>> {
-        let url = format!("{}", self.sapi_base_url.clone() + "/services");
+    pub fn list_services(&self) -> Result<Services, Box<dyn std::error::Error>> {
+        let url = format!("{}/services", self.sapi_base_url.clone());
         let sdata: Services = self.get(&url)?.json()?;
         Ok(sdata)
     }
 
     /// get service by UUID
-    pub fn get_service(
-        &self,
-        uuid: &str
-    ) -> Result<ServiceData, Box<dyn std::error::Error>> {
-        let url = format!("{}", self.sapi_base_url.clone()
-                            + "/service/{}" + uuid);
+    pub fn get_service(&self, uuid: &str) -> Result<ServiceData, Box<dyn std::error::Error>> {
+        let url = format!("{}/services/{}", self.sapi_base_url.clone(), uuid);
         let sdata: ServiceData = self.get(&url)?.json()?;
         Ok(sdata)
     }
@@ -154,13 +134,13 @@ impl SAPI {
     pub fn create_service(
         &self,
         name: &str,
-        application_uuid: &str
+        application_uuid: &str,
     ) -> Result<Response, Box<dyn std::error::Error>> {
         let body = json!({
             "name": name,
             "application_uuid": application_uuid
         });
-        let url = format!("{}", self.sapi_base_url.clone() + "/services");
+        let url = format!("{}/services", self.sapi_base_url.clone());
         self.post(&url, &body)
     }
 
@@ -168,20 +148,18 @@ impl SAPI {
     pub fn update_service(
         &self,
         service_uuid: &str,
-        body: Value
+        body: Value,
     ) -> Result<Response, Box<dyn std::error::Error>> {
-        let url = format!("{}", self.sapi_base_url.clone()
-                          + "/services/{}" + service_uuid);
+        let url = format!("{}/services/{}", self.sapi_base_url.clone(), service_uuid);
         self.post(&url, &body)
     }
 
     ///
     pub fn delete_service(
         &self,
-        service_uuid: &str
+        service_uuid: &str,
     ) -> Result<Response, Box<dyn std::error::Error>> {
-        let url = format!("{}", self.sapi_base_url.clone()
-                          + "/services/{}" + service_uuid);
+        let url = format!("{}/services/{}", self.sapi_base_url.clone(), service_uuid);
         self.delete(&url)
     }
 
@@ -197,30 +175,28 @@ impl SAPI {
     }
 
     /// Generic get -- results deserialized by caller
-    fn get<S>(
-        &self,
-        url: S
-    ) -> Result<Response, Box<dyn std::error::Error>>
+    fn get<S>(&self, url: S) -> Result<Response, Box<dyn std::error::Error>>
     where
-        S: IntoUrl
+        S: IntoUrl,
     {
-        match self.client.get(url).headers_011(self.default_headers()).send() {
+        match self
+            .client
+            .get(url)
+            .headers_011(self.default_headers())
+            .send()
+        {
             Ok(response) => Ok(response),
-            Err(e) => Err(Box::new(e))
+            Err(e) => Err(Box::new(e)),
         }
     }
 
     /// Generic post
-    fn post<S>(
-        &self,
-        url: S,
-        body: &Value
-    ) -> Result<Response, Box<dyn std::error::Error>>
+    fn post<S>(&self, url: S, body: &Value) -> Result<Response, Box<dyn std::error::Error>>
     where
         S: IntoUrl,
     {
-
-        let resp = self.client
+        let resp = self
+            .client
             .post(url)
             .headers_011(self.default_headers())
             .json(&body)
@@ -229,15 +205,12 @@ impl SAPI {
     }
 
     /// Generic delete
-    fn delete<S>(
-        &self,
-        url: S,
-    ) -> Result<Response, Box<dyn std::error::Error>>
+    fn delete<S>(&self, url: S) -> Result<Response, Box<dyn std::error::Error>>
     where
         S: IntoUrl,
     {
-
-        let resp = self.client
+        let resp = self
+            .client
             .delete(url)
             .headers_011(self.default_headers())
             .send()?;
@@ -263,16 +236,14 @@ fn test_services() {
     match client.create_service(&name, &s_uuid.to_string()) {
         Ok(resp) => {
             assert_eq!(resp.status().is_success(), true);
-        },
-        Err(_e) => {
-            assert!(false)
         }
+        Err(_e) => assert!(false),
     }
 
     match client.list_services() {
         Ok(list) => {
             assert_ne!(list.len(), 0);
-        },
+        }
         Err(e) => {
             info!(log, "Error: {:?}", e);
             assert!(false)
@@ -283,10 +254,8 @@ fn test_services() {
 
     match client.get_zone_config(&zone_uuid) {
         Ok(resp) => {
-            assert_eq!(resp.metadata["SERVICE_NAME"],
-                       "2.moray.orbit.example.com");
-        },
-        Err(e) => error!(log, "error: {:?}",  e)
+            assert_eq!(resp.metadata["SERVICE_NAME"], "2.moray.orbit.example.com");
+        }
+        Err(e) => error!(log, "error: {:?}", e),
     }
 }
-

--- a/sapi/src/lib.rs
+++ b/sapi/src/lib.rs
@@ -42,9 +42,8 @@ pub struct ServiceData {
     uuid: String,
     application_uuid: String,
     params: Value,
+    #[serde(default)]
     metadata: Value,
-    #[serde(rename = "type")]
-    svc_type: ServiceType,
     #[serde(default)]
     master: bool,
 }
@@ -92,7 +91,6 @@ impl SAPI {
     pub fn list_services(
         &self
     ) -> Result<Vec<ServiceData>, Box<dyn std::error::Error>> {
-
         let url = format!("{}", self.sapi_base_url.clone() + "/services");
         let sdata: Vec<ServiceData> = self.get(&url)?.json()?;
         Ok(sdata)


### PR DESCRIPTION
MANTA-4848 rust-triton-clients should be fmt and clippy clean
MANTA-4849 rust-triton-clients needs to specify an exact version of unicode-normalization
MANTA-4854 rust-triton-clients has some unused imports
